### PR TITLE
Fixed an error while trying to compile the module.

### DIFF
--- a/android/src/main/java/io/codebakery/imagerotate/ImageRotatePackage.java
+++ b/android/src/main/java/io/codebakery/imagerotate/ImageRotatePackage.java
@@ -18,7 +18,7 @@ public class ImageRotatePackage implements ReactPackage {
             new ImageRotateModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
The 'createJSModules()' was deprecated in RN 0.47