### PR TITLE
"Calling bride.imageLoader is deprecated..." warning fix

### DIFF
--- a/RNImageRotate/ImageRotateModule.m
+++ b/RNImageRotate/ImageRotateModule.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(rotateImage:(NSURLRequest *)imageURL
                   errorCallback:(RCTResponseErrorBlock)errorCallback)
 {
 
-  [_bridge.imageLoader loadImageWithURLRequest:imageURL callback:^(NSError *error, UIImage *image) {
+  [[_bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:imageURL callback:^(NSError *error, UIImage *image) {
     if (error) {
       errorCallback(error);
       return;


### PR DESCRIPTION
Fixed `Calling bride.imageLoader is deprecated and will not work in newer versions of RN. Please update to the moduleForClass API or turboModuleLookupDelegate API` warning (iOS)

![Captură de ecran din 2021-03-01 la 15 27 20](https://user-images.githubusercontent.com/26307699/109503893-82f0a900-7aa3-11eb-947c-6dc6b78757cf.png)